### PR TITLE
Travis CI Intergration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ python: # 3.0 is not supported on Travis CI
     - "3.7"
 install:
     - python setup.py install
-script: pytest tests/sig
+script: pytest tests/


### PR DESCRIPTION
Hello everyone, 

This pull-request would enable Travis CI to install and test the library only on Linux. This is because Windows & Mac don't support Python yet (as per Travis CI). Please review this: https://docs.travis-ci.com/user/languages/python/ 

Few notes on building on OSX: 

However, there are workarounds, like this: https://github.com/travis-ci/travis-ci/issues/9929 but I would not recommend them as they would really complicate the build process.

Few notes on building on Windows: 

Travis CI only supports only a single version of Windows. It is based on a Windows server. Please check: https://docs.travis-ci.com/user/reference/windows/#windows-version

Thanks! 

**EDIT:** This is @mahmoudalismail but I was using Raymond's account to send the pull-request. Apologies for this! 