### PR TITLE
Adding back PYTHONPATH to use repo audlib resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ cache: pip
 install:
     - pip install ".[tests]"
 script: pytest tests/
+env:
+    - PYTHONPATH=`pwd`


### PR DESCRIPTION
Without `PYTHONPATH` pytest will use the pip installed audlib in site-packages instead of the audlib in the cloned repository. Only the repository audlib have access to the resource folders.